### PR TITLE
Use HTTPS for repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@hapi/tlds",
     "description": "TLDS list for domain validation",
     "version": "1.1.7",
-    "repository": "git://github.com/hapijs/tlds",
+    "repository": "https://github.com/hapijs/tlds",
     "type": "module",
     "tshy": {
         "main": true,


### PR DESCRIPTION
## Summary
- update the package repository URL to use HTTPS instead of the legacy git protocol

## Validation
- git diff --check
- node -e 'JSON.parse(require("fs").readFileSync("package.json","utf8"))'